### PR TITLE
Add timestamp to todo tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ python todo_cli.py complete 1
 python todo_cli.py remove 1
 ```
 
-Tasks are stored in `todo.json` in the project directory.
+Each task is stored with its creation timestamp in `todo.json` in the project directory.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,5 +38,14 @@ class TodoCLITest(unittest.TestCase):
         output = self.run_cli('list')
         self.assertEqual('', output)
 
+    def test_timestamp_added(self):
+        self.run_cli('add', 'Timed Task')
+        with open(TODO_FILE) as f:
+            tasks = json.load(f)
+        self.assertIn('created_at', tasks[0])
+        # Validate ISO format
+        from datetime import datetime
+        datetime.fromisoformat(tasks[0]['created_at'])
+
 if __name__ == '__main__':
     unittest.main()

--- a/todo_cli.py
+++ b/todo_cli.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import os
+from datetime import datetime
 
 TODO_FILE = 'todo.json'
 
@@ -23,7 +24,12 @@ def save_tasks(tasks):
 def add_task(description):
     tasks = load_tasks()
     task_id = tasks[-1]['id'] + 1 if tasks else 1
-    tasks.append({'id': task_id, 'description': description, 'completed': False})
+    tasks.append({
+        'id': task_id,
+        'description': description,
+        'completed': False,
+        'created_at': datetime.now().isoformat(),
+    })
     save_tasks(tasks)
     print(f"Added task {task_id}: {description}")
 
@@ -34,7 +40,11 @@ def list_tasks(show_all=False):
         if not show_all and task['completed']:
             continue
         status = '✓' if task['completed'] else ' '
-        print(f"[{status}] {task['id']}: {task['description']}")
+        created_at = task.get('created_at')
+        if created_at:
+            print(f"[{status}] {task['id']}: {task['description']} ({created_at})")
+        else:
+            print(f"[{status}] {task['id']}: {task['description']}")
 
 
 def complete_task(task_id):


### PR DESCRIPTION
## Summary
- track when tasks are created with a `created_at` field
- display timestamp when listing tasks
- document timestamps in README
- test timestamp creation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68406416189c83308bbdd5ac23a026d0